### PR TITLE
Development

### DIFF
--- a/.quiklist/quiklist.json
+++ b/.quiklist/quiklist.json
@@ -37,6 +37,13 @@
     },
     {
       "checked": true,
+      "description": "fix the unchecked option in the show command",
+      "priority": "HIGH",
+      "createdAt": "2025-10-16T15:09:59.799Z",
+      "updatedAt": "2025-10-25T05:28:25.256Z"
+    },
+    {
+      "checked": true,
       "description": "make sure that the global list's name cannot be changed",
       "priority": "MEDIUM",
       "createdAt": "2025-09-03T16:37:43.468Z",
@@ -65,26 +72,26 @@
     },
     {
       "checked": true,
-      "description": "fix the unchecked option in the show command",
+      "description": "create consolidated command to handle all possible scenarios through ql/qlg",
       "priority": "HIGH",
-      "createdAt": "2025-10-16T15:09:59.799Z",
-      "updatedAt": "2025-10-25T05:28:25.256Z"
+      "createdAt": "2025-09-02T21:21:05.155Z",
+      "updatedAt": "2026-03-05T00:07:44.236Z"
     }
   ],
   "unchecked": [
     {
       "checked": false,
-      "description": "create consolidated command to handle all possible scenarios through ql/qlg",
+      "description": "add unchecked flag to config and modify available command args for show command allowing user config on how they prefer to see their items",
       "priority": "HIGH",
-      "createdAt": "2025-09-02T21:21:05.155Z",
-      "updatedAt": "2025-09-09T19:37:47.048Z"
+      "createdAt": "2025-10-28T05:26:22.190Z",
+      "updatedAt": "2025-10-28T05:26:22.190Z"
     },
     {
       "checked": false,
-      "description": "add email service, both sending to send and others (maybe)",
+      "description": "add email service, both sending to self and others (maybe)",
       "priority": "MEDIUM",
       "createdAt": "2025-09-02T21:22:41.463Z",
-      "updatedAt": "2025-09-09T19:37:47.048Z"
+      "updatedAt": "2025-12-23T05:51:44.739Z"
     }
   ]
 }

--- a/.quiklist/quiklist.json
+++ b/.quiklist/quiklist.json
@@ -51,6 +51,13 @@
     },
     {
       "checked": true,
+      "description": "update readme to v2 commands and functionality",
+      "priority": "MEDIUM",
+      "createdAt": "2025-09-09T23:36:06.325Z",
+      "updatedAt": "2025-09-09T23:36:20.422Z"
+    },
+    {
+      "checked": true,
       "description": "make using an editor for text input as an option in the main config",
       "priority": "LOW",
       "createdAt": "2025-09-02T21:23:12.628Z",
@@ -58,10 +65,10 @@
     },
     {
       "checked": true,
-      "description": "update readme to v2 commands and functionality",
-      "priority": "MEDIUM",
-      "createdAt": "2025-09-09T23:36:06.325Z",
-      "updatedAt": "2025-09-09T23:36:20.422Z"
+      "description": "fix the unchecked option in the show command",
+      "priority": "HIGH",
+      "createdAt": "2025-10-16T15:09:59.799Z",
+      "updatedAt": "2025-10-25T05:28:25.256Z"
     }
   ],
   "unchecked": [
@@ -78,13 +85,6 @@
       "priority": "MEDIUM",
       "createdAt": "2025-09-02T21:22:41.463Z",
       "updatedAt": "2025-09-09T19:37:47.048Z"
-    },
-    {
-      "checked": false,
-      "description": "fix the unchecked option in the show command",
-      "priority": "HIGH",
-      "createdAt": "2025-10-16T15:09:59.799Z",
-      "updatedAt": "2025-10-16T15:09:59.808Z"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quiklist",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "index.js",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quiklist",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "index.js",
   "type": "module",
   "scripts": {

--- a/src/v2/commands/config.ts
+++ b/src/v2/commands/config.ts
@@ -33,6 +33,7 @@ export const showConfig = (
     sortOrder: metadata.sortOrder,
     dateFormat: config.dateFormat,
     useEditorForUpdates: config.useEditorForUpdatingText,
+    showUncheckedItemsOnly: config.showUncheckedItemsOnly,
   };
   logger.hex(
     DEBUG_HEX,
@@ -59,6 +60,7 @@ export const modifyConfig = async (
     sortOrder: metadata.sortOrder,
     dateFormat: config.dateFormat,
     useEditorForUpdatingText: config.useEditorForUpdatingText,
+    showUncheckedItemsOnly: config.showUncheckedItemsOnly,
   };
 
   const userSelectedOptionToModify = await userConfigChangePrompt(
@@ -75,7 +77,12 @@ export const modifyConfig = async (
   const selectedOption = splitSetting[0];
   const currentValue = splitSetting[1];
 
-  const config_options = ["userName", "dateFormat", "useEditorForUpdatingText"];
+  const config_options = [
+    "userName",
+    "dateFormat",
+    "useEditorForUpdatingText",
+    "showUncheckedItemsOnly",
+  ];
 
   const text_input_options = ["listName", "userName"];
 
@@ -102,13 +109,15 @@ export const modifyConfig = async (
       sortOrder: sort_orders,
       dateFormat: date_formats,
       useEditorForUpdatingText: ["Yes", "No"] as const,
+      showUncheckedItemsOnly: ["Yes", "No"] as const,
     };
 
     const selectRes = await getSingleSelectPrompt({
       message: `Select new value for '${selectedOption}': `,
       choices: choiceMapping[selectedOption as keyof typeof choiceMapping],
       default:
-        selectedOption === "useEditorForUpdatingText"
+        selectedOption === "useEditorForUpdatingText" ||
+        selectedOption === "showUncheckedItemsOnly"
           ? currentValue === "true"
             ? "Yes"
             : "No"
@@ -128,10 +137,15 @@ export const modifyConfig = async (
     const updatedConfig =
       selectedOption === "useEditorForUpdatingText"
         ? {
-          ...config,
-          useEditorForUpdatingText: updatedValue === "Yes" ? true : false,
-        }
-        : { ...config, [selectedOption]: updatedValue };
+            ...config,
+            useEditorForUpdatingText: updatedValue === "Yes" ? true : false,
+          }
+        : selectedOption === "showUncheckedItemsOnly"
+          ? {
+              ...config,
+              showUncheckedItemsOnly: updatedValue === "Yes" ? true : false,
+            }
+          : { ...config, [selectedOption]: updatedValue };
 
     const saveConfigRes = saveConfig(updatedConfig, configFilepath);
 

--- a/src/v2/commands/index.ts
+++ b/src/v2/commands/index.ts
@@ -13,7 +13,7 @@ export const addCommand = new Command("add");
 export const showCommand = new Command("show")
   .description("Show the items in this checklist.")
   .option(
-    "-u [unchecked]",
+    "-u, [unchecked]",
     "Only show the unchecked items in the list.",
     false,
   );

--- a/src/v2/commands/index.ts
+++ b/src/v2/commands/index.ts
@@ -10,13 +10,14 @@ export const createListCommand = new Command("create")
   .description("Create a new quiklist in the current directory.")
   .option("-y", "Create the list with the default options.", false);
 export const addCommand = new Command("add");
-export const showCommand = new Command("show")
-  .description("Show the items in this checklist.")
-  .option(
-    "-u, [unchecked]",
-    "Only show the unchecked items in the list.",
-    false,
-  );
+export const showCommand = new Command("show").description(
+  "Show the items in this checklist.",
+);
+// .option(
+//   "-u, [unchecked]",
+//   "Only show the unchecked items in the list.",
+//   false,
+// );
 export const markCommand = new Command("mark").description(
   "Mark/Unmark item(s).",
 );

--- a/src/v2/commands/init.ts
+++ b/src/v2/commands/init.ts
@@ -30,6 +30,7 @@ const initGlobalConfig = async (configFilepath: string) => {
     userName: "John Doe",
     dateFormat: "DD-MM-YYYY",
     useEditorForUpdatingText: false,
+    showUncheckedItemsOnly: false,
   };
 
   const configRes = await getQuiklistConfigPrompt(defaultConfig);

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -123,13 +123,28 @@ export const launchQuiklist = (appVersion: string) => {
       });
 
     // show command
-    showCommand.action(async (options) =>
-      asyncErrorHandler(
+    if (config.showUncheckedItemsOnly) {
+      showCommand.option(
+        "-c, --checked",
+        "Show items completed in the quiklist.",
+        false,
+      );
+    } else {
+      showCommand.option(
+        "-u, --unchecked",
+        "Show incomplete items in the quiklist",
+        false,
+      );
+    }
+
+    showCommand.action(async (options) => {
+      return asyncErrorHandler(
         showListItems(
           options.global
             ? globalMetadata.datasetFilepath
             : metadata.datasetFilepath,
-          options.u,
+          // options.u,
+          config.showUncheckedItemsOnly ? !options.checked : options.unchecked,
           config.dateFormat,
           options.global
             ? globalMetadata.priorityStyle
@@ -138,8 +153,8 @@ export const launchQuiklist = (appVersion: string) => {
           options.global ? globalMetadata.sortOrder : metadata.sortOrder,
           options.global ? globalMetadata.name : metadata.name,
         ),
-      ),
-    );
+      );
+    });
 
     // mark command
     markCommand.action(async (options) =>
@@ -351,21 +366,36 @@ export const launchGlobalQuiklist = (appVersion: string) => {
       });
 
     // show command
+    if (config.showUncheckedItemsOnly) {
+      showCommand.option(
+        "-c, --checked",
+        "Show items completed in the quiklist.",
+        false,
+      );
+    } else {
+      showCommand.option(
+        "-u, --unchecked",
+        "Show incomplete items in the quiklist",
+        false,
+      );
+    }
+
     showCommand
       .description("Show items in your global quiklist.")
-      .action(async (options) =>
-        asyncErrorHandler(
+      .action(async (options) => {
+        return asyncErrorHandler(
           showListItems(
             globalMetadata.datasetFilepath,
-            options.u,
+            // options.u,
+            config.showUncheckedItemsOnly ? !options.c : options.u,
             config.dateFormat,
             globalMetadata.priorityStyle,
             globalMetadata.sortCriteria,
             globalMetadata.sortOrder,
             globalMetadata.name,
           ),
-        ),
-      );
+        );
+      });
 
     // mark command
     markCommand

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -129,7 +129,7 @@ export const launchQuiklist = (appVersion: string) => {
           options.global
             ? globalMetadata.datasetFilepath
             : metadata.datasetFilepath,
-          options.unchecked,
+          options.u,
           config.dateFormat,
           options.global
             ? globalMetadata.priorityStyle
@@ -353,19 +353,19 @@ export const launchGlobalQuiklist = (appVersion: string) => {
     // show command
     showCommand
       .description("Show items in your global quiklist.")
-      .action(async (options) => {
-        return asyncErrorHandler(
+      .action(async (options) =>
+        asyncErrorHandler(
           showListItems(
             globalMetadata.datasetFilepath,
-            options.unchecked,
+            options.u,
             config.dateFormat,
             globalMetadata.priorityStyle,
             globalMetadata.sortCriteria,
             globalMetadata.sortOrder,
             globalMetadata.name,
           ),
-        );
-      });
+        ),
+      );
 
     // mark command
     markCommand

--- a/src/v2/lib/prompt.ts
+++ b/src/v2/lib/prompt.ts
@@ -464,10 +464,10 @@ export const getGlobalListOptionsPrompt = async (
   const sortOrderRes =
     sortCriteriaRes.value !== "none"
       ? await getSingleSelectPrompt({
-        message: "Sort ordering: ",
-        default: defaultGlobalListOptions.sortOrder,
-        choices: sort_orders,
-      })
+          message: "Sort ordering: ",
+          default: defaultGlobalListOptions.sortOrder,
+          choices: sort_orders,
+        })
       : ok(defaultGlobalListOptions.sortOrder);
   if (sortOrderRes.isErr())
     return err({
@@ -520,9 +520,22 @@ export const getQuiklistConfigPrompt = async (
       location: `${useEditorRes.error.location} -> getQuiklistConfigPrompt:useEditor`,
     });
 
+  const showUcheckedItemsOnlyRes = await getConfirmPrompt({
+    message:
+      "Do you want to show only incomplete items in your quiklist by default? (This can be changed anytime in the future & can be altered per use.)",
+    default: defaultConfig.showUncheckedItemsOnly,
+  });
+
+  if (showUcheckedItemsOnlyRes.isErr())
+    return err({
+      ...showUcheckedItemsOnlyRes.error,
+      location: `${showUcheckedItemsOnlyRes.error.location} -> getQuiklistConfigPrompt:useEditor`,
+    });
+
   return ok({
     userName: userNameRes.value,
     dateFormat: dateFormatRes.value,
     useEditorForUpdatingText: useEditorRes.value,
+    showUncheckedItemsOnly: showUcheckedItemsOnlyRes.value,
   });
 };

--- a/src/v2/types/config.ts
+++ b/src/v2/types/config.ts
@@ -4,6 +4,7 @@ export type QLUserInputtedConfig = {
   userName: string;
   dateFormat: DateFormat;
   useEditorForUpdatingText: boolean;
+  showUncheckedItemsOnly: boolean;
 };
 
 export type QLCompleteConfig = QLUserInputtedConfig & {


### PR DESCRIPTION
Added option to config to allow users to view only incomplete items. Based on their config, the show command options also change to allow greater one-time visibility if required. Also modified the init process to allow users to set this value while creating the quiklist. Finally, also modified the show and edit config commands to provision for this extra option.